### PR TITLE
139 dont mark sms permanently failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,12 @@ Gateway will retry to send the SMS when any of these errors occurs: `RESULT_ERRO
 1. A possible temporary error occurs and Gateway retries sending the SMS:
     1.1 SMS status will be updated to `UNSENT`, so Gateway will find it and add it into the `send queue` automatically.
     1.2 SMS' `retry counter` increases by 1.
-    1.3 Gateway logs that X error occurred and that will retry for the X time in X minutes.
+    1.3 The retry attempt is scheduled based on this formula: `SMS' last activity time + ( 3 minutes * retry counter )`. This means the time between retries is incremental.
+    1.4 Gateway logs: the error, the retry counter and the retry scheduled time. Sample: `Sending SMS to +1123123123 failed (cause: radio off) Retry #5 in 15 min`
 
-2. If the SMS retry limit is reached, then:
+2. Gateway has a maximum limit of attempts to retry sending SMS (currently 20), If this is reached then:
     2.1 Gateway will hard fail the SMS by updating its status to `FAILED` and won't retry again.
-    2.2 Gateway logs error.
+    2.2 Gateway logs error. Sample: `Sending message to +1123123123 failed (cause: radio off) Not retrying`
 
 3. At this point the user has the option of manually select the SMS and press `Retry` button.
     3.1 If they do and SMS fails again, then the process will restart from step # 1.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Bar array behaviour specified above, `medic-gateway` _must_ include fields speci
 
 ## Idempotence
 
-N.B. messages are cosidered duplicate by `medic-gateway` if they have identical values for `id`.  The webapp is expected to do the same.
+N.B. messages are considered duplicate by `medic-gateway` if they have identical values for `id`.  The webapp is expected to do the same.
 
 `medic-gateway` will not re-process duplicate webapp-originating messages.
 
@@ -191,6 +191,21 @@ The `message` property may be logged and/or displayed to users in the `medic-gat
 
 Treatment of response codes below `200` and between `300` and `399` will _probably_ be handled sensibly by Android.
 
+# SMS Retry Mechanism
+
+Gateway will retry to send the SMS when any of these errors occurs: `RESULT_ERROR_NO_SERVICE`, `RESULT_ERROR_NULL_PDU` and `RESULT_ERROR_RADIO_OFF`.
+
+1. A possible temporary error occurs and Gateway retries sending the SMS:
+    1.1 SMS status will be updated to `UNSENT`, so Gateway will find it and add it into the `send queue` automatically.
+    1.2 SMS' `retry counter` increases by 1.
+    1.3 Gateway logs that X error occurred and that will retry for the X time in X minutes.
+
+2. If the SMS retry limit is reached, then:
+    2.1 Gateway will hard fail the SMS by updating its status to `FAILED` and won't retry again.
+    2.2 Gateway logs error.
+
+3. At this point the user has the option of manually select the SMS and press `Retry` button.
+    3.1 If they do and SMS fails again, then the process will restart from step # 1.
 
 # Development
 
@@ -273,7 +288,7 @@ TODO walkthrough
 
 Some changes were made to the Android SMS APIs in 4.4 (Kitkat®).  The significant change was this:
 
-> from android 4.4 onwards, apps cannot delete messages from the device inbox _unless they are set, by the user, as the default messageing app for the device_
+> from android 4.4 onwards, apps cannot delete messages from the device inbox _unless they are set, by the user, as the default messaging app for the device_
 
 Some reading on this can be found at:
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Gateway will retry to send the SMS when any of these errors occurs: `RESULT_ERRO
 1. A possible temporary error occurs and Gateway retries sending the SMS:
     1.1 SMS status will be updated to `UNSENT`, so Gateway will find it and add it into the `send queue` automatically.
     1.2 SMS' `retry counter` increases by 1.
-    1.3 The retry attempt is scheduled based on this formula: `SMS' last activity time + ( 3 minutes * retry counter )`. This means the time between retries is incremental.
+    1.3 The retry attempt is scheduled based on this formula: `SMS' last activity time + ( 1 minute * (retry counter ^ 1.5) )`. This means the time between retries is incremental.
     1.4 Gateway logs: the error, the retry counter and the retry scheduled time. Sample: `Sending SMS to +1123123123 failed (cause: radio off) Retry #5 in 15 min`
 
 2. Gateway has a maximum limit of attempts to retry sending SMS (currently 20), If this is reached then:

--- a/build.gradle
+++ b/build.gradle
@@ -94,8 +94,8 @@ def getVersionName = {
 }
 
 android {
-	compileSdkVersion 29
-	buildToolsVersion '29.0.0'
+	compileSdkVersion 30
+	buildToolsVersion '30.0.0'
 
 	packagingOptions {
 		exclude 'META-INF/LICENSE'
@@ -104,7 +104,7 @@ android {
 
 	defaultConfig {
 		minSdkVersion 16
-		targetSdkVersion 29
+		targetSdkVersion 30
 
 		versionCode getVersionCode()
 		versionName getVersionName()

--- a/src/androidTest/java/medic/gateway/alert/IntentProcessorInstrumentationTest.java
+++ b/src/androidTest/java/medic/gateway/alert/IntentProcessorInstrumentationTest.java
@@ -177,7 +177,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 		db.assertTable("wo_message",
 				id, "UNSENT", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 1);
 		db.assertTable("wom_status",
-				ANY_NUMBER, id, "PENDING", null,         ANY_NUMBER, false,
+				ANY_NUMBER, id, "PENDING", null,        ANY_NUMBER, false,
 				ANY_NUMBER, id, "UNSENT",  null, ANY_NUMBER, true);
 	}
 

--- a/src/androidTest/java/medic/gateway/alert/IntentProcessorInstrumentationTest.java
+++ b/src/androidTest/java/medic/gateway/alert/IntentProcessorInstrumentationTest.java
@@ -77,7 +77,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 	}
 
 	@Test
-	public void test_onReceive_GENERIC_shouldUdpateSendStatusAndIncludeErrorCodeInReason() throws Exception {
+	public void test_onReceive_GENERIC_shouldUpdateSendStatusAndIncludeErrorCodeInReason() throws Exception {
 		// given
 		String id = randomUuid();
 		aWoMessageIsInDbWith(id, PENDING, 0);
@@ -98,7 +98,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 	}
 
 	@Test
-	public void test_onReceive_RADIO_OFF_shouldUdpateSendStatusAndIncludeErrorCodeInReason() throws Exception {
+	public void test_onReceive_RADIO_OFF_shouldUpdateSendStatusAndIncludeErrorCodeInReason() throws Exception {
 		// given
 		String id = randomUuid();
 		aWoMessageIsInDbWith(id, PENDING, 21); // Hard fail
@@ -119,7 +119,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 	}
 
 	@Test
-	public void test_onReceive_RADIO_OFF_shouldUdpateSendStatusAndRetryAfterSoftFail() throws Exception {
+	public void test_onReceive_RADIO_OFF_shouldUpdateSendStatusAndRetryAfterSoftFail() throws Exception {
 		// given
 		String id = randomUuid();
 		aWoMessageIsInDbWith(id, PENDING, 0);
@@ -140,7 +140,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 	}
 
 	@Test
-	public void test_onReceive_NO_SERVICE_shouldUdpateSendStatusAndIncludeErrorCodeInReason() throws Exception {
+	public void test_onReceive_NO_SERVICE_shouldUpdateSendStatusAndIncludeErrorCodeInReason() throws Exception {
 		// given
 		String id = randomUuid();
 		aWoMessageIsInDbWith(id, PENDING, 21); // Hard fail
@@ -161,7 +161,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 	}
 
 	@Test
-	public void test_onReceive_NO_SERVICE_shouldUdpateSendStatusAndRetryAfterSoftFail() throws Exception {
+	public void test_onReceive_NO_SERVICE_shouldUpdateSendStatusAndRetryAfterSoftFail() throws Exception {
 		// given
 		String id = randomUuid();
 		aWoMessageIsInDbWith(id, PENDING, 0);
@@ -182,7 +182,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 	}
 
 	@Test
-	public void test_onReceive_NULL_PDU_shouldUdpateSendStatusAndIncludeErrorCodeInReason() throws Exception {
+	public void test_onReceive_NULL_PDU_shouldUpdateSendStatusAndIncludeErrorCodeInReason() throws Exception {
 		// given
 		String id = randomUuid();
 		aWoMessageIsInDbWith(id, PENDING, 21); // Hard fail
@@ -203,7 +203,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 	}
 
 	@Test
-	public void test_onReceive_NULL_PDU_shouldUdpateSendStatusAndRetryAfterSoftFail() throws Exception {
+	public void test_onReceive_NULL_PDU_shouldUpdateSendStatusAndRetryAfterSoftFail() throws Exception {
 		// given
 		String id = randomUuid();
 		aWoMessageIsInDbWith(id, PENDING, 0);
@@ -218,6 +218,27 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 		// then
 		db.assertTable("wo_message",
 				id, "UNSENT", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 1);
+		db.assertTable("wom_status",
+				ANY_NUMBER, id, "PENDING", null,       ANY_NUMBER, false,
+				ANY_NUMBER, id, "UNSENT",  null, ANY_NUMBER, true);
+	}
+
+	@Test
+	public void test_onReceive_NULL_PDU_shouldContinueRetryAfterSoftFail() throws Exception {
+		// given
+		String id = randomUuid();
+		aWoMessageIsInDbWith(id, PENDING, 10);
+		db.assertTable("wo_message",
+				id, "PENDING", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 10);
+		db.assertTable("wom_status",
+				ANY_NUMBER, id, "PENDING", null, ANY_NUMBER, false);
+
+		// when
+		aSendFailureReportArrivesFor(id, RESULT_ERROR_NULL_PDU);
+
+		// then
+		db.assertTable("wo_message",
+				id, "UNSENT", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 11);
 		db.assertTable("wom_status",
 				ANY_NUMBER, id, "PENDING", null,       ANY_NUMBER, false,
 				ANY_NUMBER, id, "UNSENT",  null, ANY_NUMBER, true);

--- a/src/androidTest/java/medic/gateway/alert/IntentProcessorInstrumentationTest.java
+++ b/src/androidTest/java/medic/gateway/alert/IntentProcessorInstrumentationTest.java
@@ -82,7 +82,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 		String id = randomUuid();
 		aWoMessageIsInDbWith(id, PENDING);
 		db.assertTable("wo_message",
-				id, "PENDING", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT);
+				id, "PENDING", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 0);
 		db.assertTable("wom_status",
 				ANY_NUMBER, id, "PENDING", null, ANY_NUMBER, false);
 
@@ -91,7 +91,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 
 		// then
 		db.assertTable("wo_message",
-				id, "FAILED", "generic; errorCode=99", ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT);
+				id, "FAILED", "generic; errorCode=99", ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 0);
 		db.assertTable("wom_status",
 				ANY_NUMBER, id, "PENDING", null,                    ANY_NUMBER, false,
 				ANY_NUMBER, id, "FAILED",  "generic; errorCode=99", ANY_NUMBER, true);
@@ -103,7 +103,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 		String id = randomUuid();
 		aWoMessageIsInDbWith(id, PENDING);
 		db.assertTable("wo_message",
-				id, "PENDING", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT);
+				id, "PENDING", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 0);
 		db.assertTable("wom_status",
 				ANY_NUMBER, id, "PENDING", null, ANY_NUMBER, false);
 
@@ -112,7 +112,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 
 		// then
 		db.assertTable("wo_message",
-				id, "FAILED", "radio-off", ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT);
+				id, "FAILED", "radio-off", ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 0);
 		db.assertTable("wom_status",
 				ANY_NUMBER, id, "PENDING", null,        ANY_NUMBER, false,
 				ANY_NUMBER, id, "FAILED",  "radio-off", ANY_NUMBER, true);
@@ -124,7 +124,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 		String id = randomUuid();
 		aWoMessageIsInDbWith(id, PENDING);
 		db.assertTable("wo_message",
-				id, "PENDING", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT);
+				id, "PENDING", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 0);
 		db.assertTable("wom_status",
 				ANY_NUMBER, id, "PENDING", null, ANY_NUMBER, false);
 
@@ -133,7 +133,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 
 		// then
 		db.assertTable("wo_message",
-				id, "FAILED", "no-service", ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT);
+				id, "FAILED", "no-service", ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 0);
 		db.assertTable("wom_status",
 				ANY_NUMBER, id, "PENDING", null,         ANY_NUMBER, false,
 				ANY_NUMBER, id, "FAILED",  "no-service", ANY_NUMBER, true);
@@ -145,7 +145,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 		String id = randomUuid();
 		aWoMessageIsInDbWith(id, PENDING);
 		db.assertTable("wo_message",
-				id, "PENDING", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT);
+				id, "PENDING", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 0);
 		db.assertTable("wom_status",
 				ANY_NUMBER, id, "PENDING", null, ANY_NUMBER, false);
 
@@ -154,7 +154,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 
 		// then
 		db.assertTable("wo_message",
-				id, "FAILED", "null-pdu", ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT);
+				id, "FAILED", "null-pdu", ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 0);
 		db.assertTable("wom_status",
 				ANY_NUMBER, id, "PENDING", null,       ANY_NUMBER, false,
 				ANY_NUMBER, id, "FAILED",  "null-pdu", ANY_NUMBER, true);
@@ -239,8 +239,8 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 //> HELPER METHODS
 	private void aWoMessageIsInDbWith(String id, WoMessage.Status status) {
 		db.insert("wo_message",
-				cols("_id", "status", "last_action", "_to", "content"),
-				vals(id, status, 0, A_PHONE_NUMBER, SOME_CONTENT));
+				cols("_id", "status", "last_action", "_to", "content", "retries"),
+				vals(id, status, 0, A_PHONE_NUMBER, SOME_CONTENT, 0));
 		db.insert("wom_status",
 				cols("message_id", "status", "timestamp", "needs_forwarding"),
 				vals(id, status, 0, false));

--- a/src/androidTest/java/medic/gateway/alert/IntentProcessorInstrumentationTest.java
+++ b/src/androidTest/java/medic/gateway/alert/IntentProcessorInstrumentationTest.java
@@ -240,7 +240,7 @@ public class IntentProcessorInstrumentationTest extends AndroidTestCase {
 		db.assertTable("wo_message",
 				id, "UNSENT", null, ANY_NUMBER, ANY_PHONE_NUMBER, ANY_CONTENT, 11);
 		db.assertTable("wom_status",
-				ANY_NUMBER, id, "PENDING", null,       ANY_NUMBER, false,
+				ANY_NUMBER, id, "PENDING", null, ANY_NUMBER, false,
 				ANY_NUMBER, id, "UNSENT",  null, ANY_NUMBER, true);
 	}
 

--- a/src/androidTest/java/medic/gateway/alert/WebappPollerTest.java
+++ b/src/androidTest/java/medic/gateway/alert/WebappPollerTest.java
@@ -75,9 +75,9 @@ public class WebappPollerTest extends AndroidTestCase {
 		String deliveredId = randomUuid();
 		String irrelevantId = randomUuid();
 		db.insert("wo_message",
-				cols("_id",        "status",                   "last_action", "_to",          "content"),
-				vals(deliveredId,  WoMessage.Status.DELIVERED, 0,             A_PHONE_NUMBER, SOME_CONTENT),
-				vals(irrelevantId, WoMessage.Status.DELIVERED, 0,             A_PHONE_NUMBER, SOME_CONTENT));
+				cols("_id",        "status",                   "last_action", "_to",          "content", "retries"),
+				vals(deliveredId,  WoMessage.Status.DELIVERED, 0,             A_PHONE_NUMBER, SOME_CONTENT, 0),
+				vals(irrelevantId, WoMessage.Status.DELIVERED, 0,             A_PHONE_NUMBER, SOME_CONTENT, 0));
 		db.insert("wom_status",
 				cols("message_id", "status",                   "timestamp", "needs_forwarding"),
 				vals(deliveredId,  WoMessage.Status.DELIVERED, 0,            true),
@@ -103,8 +103,8 @@ public class WebappPollerTest extends AndroidTestCase {
 		// given
 		String messageId = randomUuid();
 		db.insert("wo_message",
-				cols("_id",     "status",                   "last_action", "_to",          "content"),
-				vals(messageId, WoMessage.Status.DELIVERED, 0,             A_PHONE_NUMBER, SOME_CONTENT));
+				cols("_id",     "status",                   "last_action", "_to",          "content", "retries"),
+				vals(messageId, WoMessage.Status.DELIVERED, 0,             A_PHONE_NUMBER, SOME_CONTENT, 0));
 		db.insert("wom_status",
 				cols("message_id", "status",                   "timestamp", "needs_forwarding"),
 				vals(messageId,    WoMessage.Status.DELIVERED, 0,           true));
@@ -117,7 +117,7 @@ public class WebappPollerTest extends AndroidTestCase {
 		http.assertPostRequestMade_withJsonResponse();
 		// and
 		db.assertTable("wo_message",
-				ANY_ID, "DELIVERED", NO_REASON, 0, A_PHONE_NUMBER, SOME_CONTENT);
+				ANY_ID, "DELIVERED", NO_REASON, 0, A_PHONE_NUMBER, SOME_CONTENT, 0);
 		db.assertTable("wom_status",
 				ANY_NUMBER, messageId, "DELIVERED", NO_REASON, 0, false);
 	}
@@ -127,8 +127,8 @@ public class WebappPollerTest extends AndroidTestCase {
 		// given
 		String messageId = randomUuid();
 		db.insert("wo_message",
-				cols("_id",     "status",                "failure_reason",  "last_action", "_to",          "content"),
-				vals(messageId, WoMessage.Status.FAILED, "something-awful", 0,             A_PHONE_NUMBER, SOME_CONTENT));
+				cols("_id",     "status",                "failure_reason",  "last_action", "_to",          "content", "retries"),
+				vals(messageId, WoMessage.Status.FAILED, "something-awful", 0,             A_PHONE_NUMBER, SOME_CONTENT, 0));
 		db.insert("wom_status",
 				cols("message_id", "status",                "failure_reason",  "timestamp", "needs_forwarding"),
 				vals(messageId,    WoMessage.Status.FAILED, "something-awful", 0,           true));
@@ -236,8 +236,8 @@ public class WebappPollerTest extends AndroidTestCase {
 		// then
 		http.assertSinglePostRequestMade();
 		db.assertTable("wo_message",
-				"aaa-111", "UNSENT", NO_REASON, ANY_NUMBER, "+1", "testing: one",
-				"aaa-222", "UNSENT", NO_REASON, ANY_NUMBER, "+2", "testing: two");
+				"aaa-111", "UNSENT", NO_REASON, ANY_NUMBER, "+1", "testing: one", 0,
+				"aaa-222", "UNSENT", NO_REASON, ANY_NUMBER, "+2", "testing: two", 0);
 		db.assertTable("wom_status",
 				ANY_NUMBER, "aaa-111", "UNSENT", NO_REASON, ANY_NUMBER, false,
 				ANY_NUMBER, "aaa-222", "UNSENT", NO_REASON, ANY_NUMBER, false);
@@ -258,7 +258,7 @@ public class WebappPollerTest extends AndroidTestCase {
 		// then
 		http.assertSinglePostRequestMade();
 		db.assertTable("wo_message",
-				"abc-123", "UNSENT", NO_REASON, ANY_NUMBER, "+123", "testing: abc");
+				"abc-123", "UNSENT", NO_REASON, ANY_NUMBER, "+123", "testing: abc", 0);
 		db.assertTable("wom_status",
 				ANY_NUMBER, "abc-123", "UNSENT", NO_REASON, ANY_NUMBER, false);
 	}
@@ -298,8 +298,8 @@ public class WebappPollerTest extends AndroidTestCase {
 		// then
 		http.assertSinglePostRequestMade();
 		db.assertTable("wo_message",
-				"ok-111", "UNSENT", NO_REASON, ANY_NUMBER, "+1", "ok: one",
-				"ok-222", "UNSENT", NO_REASON, ANY_NUMBER, "+2", "ok: two");
+				"ok-111", "UNSENT", NO_REASON, ANY_NUMBER, "+1", "ok: one", 0,
+				"ok-222", "UNSENT", NO_REASON, ANY_NUMBER, "+2", "ok: two", 0);
 		db.assertTable("wom_status",
 				ANY_NUMBER, "ok-111", "UNSENT", NO_REASON, ANY_NUMBER, false,
 				ANY_NUMBER, "ok-222", "UNSENT", NO_REASON, ANY_NUMBER, false);

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -60,8 +60,6 @@
 			<intent-filter android:priority="999">
 				<action android:name="android.provider.Telephony.SMS_DELIVER"/>
 				<action android:name="android.provider.Telephony.SMS_RECEIVED"/>
-				<action android:name="medic.gateway.alert.SENDING_REPORT"/>
-				<action android:name="medic.gateway.alert.DELIVERY_REPORT"/>
 			</intent-filter>
 		</receiver>
 		<!-- Android 4.4+ (kitkat) SMS support -->

--- a/src/main/java/medic/gateway/alert/Db.java
+++ b/src/main/java/medic/gateway/alert/Db.java
@@ -31,7 +31,7 @@ import static medic.gateway.alert.DebugUtils.randomSmsContent;
 
 @SuppressWarnings({"PMD.GodClass", "PMD.TooManyMethods"})
 public final class Db extends SQLiteOpenHelper {
-	private static final int SCHEMA_VERSION = 6;
+	private static final int SCHEMA_VERSION = 7;
 
 	private static final String ALL = null, NO_GROUP = null;
 	private static final String[] NO_ARGS = {};
@@ -148,13 +148,13 @@ public final class Db extends SQLiteOpenHelper {
 				tblWT_MESSAGE, WTM_clmID, WTM_clmSTATUS, WTM_clmLAST_ACTION, WTM_clmFROM, WTM_clmCONTENT, WTM_clmSMS_SENT, WTM_clmSMS_RECEIVED));
 
 		db.execSQL(String.format("CREATE TABLE %s (" +
-					"%s TEXT NOT NULL PRIMARY KEY, " +
-					"%s TEXT NOT NULL, " +
-					"%s TEXT, " +
-					"%s INTEGER NOT NULL, " +
-					"%s TEXT NOT NULL, " +
-					"%s TEXT NOT NULL, " +
-					"%s INTEGER NOT NULL)",
+						"%s TEXT NOT NULL PRIMARY KEY, " +
+						"%s TEXT NOT NULL, " +
+						"%s TEXT, " +
+						"%s INTEGER NOT NULL, " +
+						"%s TEXT NOT NULL, " +
+						"%s TEXT NOT NULL, " +
+						"%s INTEGER NOT NULL DEFAULT(0))",
 				tblWO_MESSAGE, WOM_clmID, WOM_clmSTATUS, WOM_clmFAILURE_REASON, WOM_clmLAST_ACTION, WOM_clmTO, WOM_clmCONTENT, WOM_clmRETRIES));
 
 		migrate_createTable_WoMessageStatusUpdate(db, true);
@@ -162,28 +162,38 @@ public final class Db extends SQLiteOpenHelper {
 		migrate_createTable_WtMessagePart(db, true);
 	}
 
-	public void onUpgrade(SQLiteDatabase db,
-			int oldVersion,
-			int newVersion) {
+	public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+
 		trace(this, "onUpgrade() :: oldVersion=%s, newVersion=%s", oldVersion, newVersion);
-		if(oldVersion < 2) {
+
+		if (oldVersion < 2) {
 			migrate_createTable_WoMessageStatusUpdate(db, false);
 		}
-		if(oldVersion < 3) {
+		if (oldVersion < 3) {
 			migrate_create_WOS_clmNEEDS_FORWARDING(db);
 		}
-		if(oldVersion < 4) {
+		if (oldVersion < 4) {
 			migrate_createTable_WtMessageStatusUpdate(db, false);
 		}
-		if(oldVersion < 5) {
+		if (oldVersion < 5) {
 			migrate_create_WTM_clmSMS_SENT__clmSMS_RECEIVED(db);
 		}
-		if(oldVersion < 6) {
+		if (oldVersion < 6) {
 			migrate_createTable_WtMessagePart(db, false);
+		}
+		if (oldVersion < 7) {
+			migrate_addRetriesColumn_WoMessage(db);
 		}
 	}
 
 //> MIGRATIONS
+	static void migrate_addRetriesColumn_WoMessage(SQLiteDatabase db) {
+		trace(db, "onUpgrade() :: migrate_addRetriesColumn_WoMessage()");
+
+		db.execSQL(String.format("ALTER TABLE %s ADD COLUMN %s INTEGER NOT NULL DEFAULT(0)",
+				tblWO_MESSAGE, WOM_clmRETRIES));
+	}
+
 	static void migrate_createTable_WoMessageStatusUpdate(SQLiteDatabase db, boolean isCleanDb) {
 		trace(db, "onUpgrade() :: migrate_createTable_WoMessageStatusUpdate()");
 		db.execSQL(String.format("CREATE TABLE %s (" +

--- a/src/main/java/medic/gateway/alert/IntentProcessor.java
+++ b/src/main/java/medic/gateway/alert/IntentProcessor.java
@@ -11,8 +11,6 @@ import static android.telephony.SmsManager.RESULT_ERROR_GENERIC_FAILURE;
 import static android.telephony.SmsManager.RESULT_ERROR_NO_SERVICE;
 import static android.telephony.SmsManager.RESULT_ERROR_NULL_PDU;
 import static android.telephony.SmsManager.RESULT_ERROR_RADIO_OFF;
-import static android.telephony.SmsManager.RESULT_SMS_SEND_RETRY_FAILED;
-import static android.telephony.SmsManager.RESULT_NETWORK_ERROR;
 import static medic.gateway.alert.GatewayLog.logEvent;
 import static medic.gateway.alert.GatewayLog.logException;
 import static medic.gateway.alert.SmsCompatibility.getMessagesFromIntent;
@@ -144,12 +142,6 @@ class SendingReportHandler {
 					break;
 				case RESULT_ERROR_NO_SERVICE:
 					this.softFail(db, m, "no-service");
-					break;
-				case RESULT_NETWORK_ERROR:
-					this.softFail(db, m, "network-error");
-					break;
-				case RESULT_SMS_SEND_RETRY_FAILED:
-					this.softFail(db, m, "send-retry-failed");
 					break;
 				case RESULT_ERROR_NULL_PDU:
 					this.softFail(db, m, "null-pdu");

--- a/src/main/java/medic/gateway/alert/SmsSender.java
+++ b/src/main/java/medic/gateway/alert/SmsSender.java
@@ -61,13 +61,11 @@ public class SmsSender {
 		} else {
 			logEvent(ctx, "Sending %d SMSs...", smsForSending.size());
 
-			for(int i = 0; i < smsForSending.size(); i++) {
-				WoMessage m = smsForSending.get(i);
-
+			for(WoMessage m : smsForSending) {
 				try {
 					trace(this, "sendUnsentSmses() :: attempting to send %s", m);
 					if(dummySendMode) sendSms_dummy(m);
-					else sendSms(m, i);
+					else sendSms(m);
 				} catch(Exception ex) {
 					logException(ex, "SmsSender.sendUnsentSmses() :: message=%s", m);
 					db.setFailed(m, String.format("Exception: %s; message: %s; cause: %s",
@@ -77,7 +75,7 @@ public class SmsSender {
 		}
 	}
 
-	private void sendSms(WoMessage m, int mIdx) {
+	private void sendSms(WoMessage m) {
 		logEvent(ctx, "sendSms() :: [%s] '%s'", m.to, m.content);
 
 		boolean statusUpdated = db.updateStatus(m, UNSENT, PENDING);
@@ -92,8 +90,8 @@ public class SmsSender {
 								m.to,
 								DEFAULT_SMSC,
 								part,
-								intentFor(SENDING_REPORT, m, mIdx, partIndex, totalParts, IntentProcessor.class),
-								intentFor(DELIVERY_REPORT, m, mIdx, partIndex, totalParts, IntentProcessor.class));
+								intentFor(SENDING_REPORT, m, partIndex, totalParts),
+								intentFor(DELIVERY_REPORT, m, partIndex, totalParts));
 					}
 				} else {
 					ArrayList<String> parts = smsManager.divideMessage(m.content);
@@ -101,8 +99,8 @@ public class SmsSender {
 							m.to,
 							DEFAULT_SMSC,
 							parts,
-							intentsFor(SENDING_REPORT, m, mIdx, parts, IntentProcessor.class),
-							intentsFor(DELIVERY_REPORT, m, mIdx, parts, IntentProcessor.class));
+							intentsFor(SENDING_REPORT, m, parts),
+							intentsFor(DELIVERY_REPORT, m, parts));
 				}
 			} else {
 				logEvent(ctx, "Not sending SMS to '%s' because number appears invalid (content: '%s')",
@@ -119,23 +117,23 @@ public class SmsSender {
 		db.updateStatus(m, SENT, DELIVERED);
 	}
 
-	private ArrayList<PendingIntent> intentsFor(String intentType, WoMessage m, int mIdx, ArrayList<String> parts, Class<?> receiverClass) {
+	private ArrayList<PendingIntent> intentsFor(String intentType, WoMessage m, ArrayList<String> parts) {
 		int totalParts = parts.size();
 		ArrayList<PendingIntent> intents = new ArrayList<>(totalParts);
 		for(int partIndex=0; partIndex<totalParts; ++partIndex) {
-			intents.add(intentFor(intentType, m, mIdx, partIndex, totalParts, receiverClass));
+			intents.add(intentFor(intentType, m, partIndex, totalParts));
 		}
 		return intents;
 	}
 
-	private PendingIntent intentFor(String intentType, WoMessage m, int mIdx, int partIndex, int totalParts, Class<?> receiverClass) {
-		Intent intent = new Intent(ctx, receiverClass);
+	private PendingIntent intentFor(String intentType, WoMessage m, int partIndex, int totalParts) {
+		Intent intent = new Intent(ctx, IntentProcessor.class);
 		intent.setAction(intentType);
 		intent.putExtra("id", m.id);
 		intent.putExtra("partIndex", partIndex);
 		intent.putExtra("totalParts", totalParts);
 
-		return PendingIntent.getBroadcast(ctx, mIdx, intent, PendingIntent.FLAG_ONE_SHOT);
+		return PendingIntent.getBroadcast(ctx, m.hashCode(), intent, PendingIntent.FLAG_ONE_SHOT);
 	}
 
 	/**

--- a/src/main/java/medic/gateway/alert/SmsSender.java
+++ b/src/main/java/medic/gateway/alert/SmsSender.java
@@ -54,7 +54,7 @@ public class SmsSender {
 	}
 
 	public void sendUnsentSmses() {
-		List<WoMessage> smsForSending = db.getWoMessages(MAX_WO_MESSAGES, UNSENT);
+		List<WoMessage> smsForSending = this.getUnsentMessages();
 
 		if(smsForSending.isEmpty()) {
 			logEvent(ctx, "No SMS waiting to be sent.");
@@ -179,5 +179,22 @@ public class SmsSender {
 		for(int i=s.length()-1; i>=0; --i)
 			if(s.charAt(i) > 255) return false;
 		return true;
+	}
+
+	private List<WoMessage> getUnsentMessages() {
+		List<WoMessage> unsentSms = db.getWoMessages(MAX_WO_MESSAGES, UNSENT);
+		List<WoMessage> smsForSending = new ArrayList<>();
+
+		for(WoMessage sms : unsentSms) {
+			if (sms.retries > 0) {
+				if (sms.canRetryAfterSoftFail()) {
+					smsForSending.add(sms);
+				}
+			} else {
+				smsForSending.add(sms);
+			}
+		}
+
+		return smsForSending;
 	}
 }

--- a/src/main/java/medic/gateway/alert/SmsSender.java
+++ b/src/main/java/medic/gateway/alert/SmsSender.java
@@ -133,7 +133,7 @@ public class SmsSender {
 		intent.putExtra("partIndex", partIndex);
 		intent.putExtra("totalParts", totalParts);
 
-		return PendingIntent.getBroadcast(ctx, m.hashCode(), intent, PendingIntent.FLAG_ONE_SHOT);
+		return PendingIntent.getBroadcast(ctx, m.id.hashCode(), intent, PendingIntent.FLAG_ONE_SHOT);
 	}
 
 	/**

--- a/src/main/java/medic/gateway/alert/WoMessage.java
+++ b/src/main/java/medic/gateway/alert/WoMessage.java
@@ -71,8 +71,8 @@ class WoMessage {
 	// Retries is a counter. After a soft fail the WoMessage's status is set to UNSENT, then Gateway will retry to send it.
 	// After limit is reached, WoMessage will hard fail. It can be retried manually later.
 	public final int retries;
-	private static final int MAX_RETRIES_SOFT_FAIL = 20; // Aprox 10H when WAIT_RETRY_SOFT_FAIL is 3min
-	private static final int WAIT_RETRY_SOFT_FAIL = 3 * 60 * 1000; // Milliseconds
+	private static final int MAX_RETRIES_SOFT_FAIL = 20; // Aprox 12H when WAIT_RETRY_SOFT_FAIL is 1min
+	private static final int WAIT_RETRY_SOFT_FAIL = 60 * 1000; // Milliseconds
 
 	public WoMessage(String id, String to, String content) {
 		this.id = id;
@@ -120,7 +120,7 @@ class WoMessage {
 	 * @return time in milliseconds
 	 */
 	public int calcWaitTimeRetry(int retries) {
-		return WAIT_RETRY_SOFT_FAIL * retries;
+		return (int) ( WAIT_RETRY_SOFT_FAIL * Math.pow(retries, 1.5) );
 	}
 
 	public boolean canRetryAfterSoftFail() {

--- a/src/main/java/medic/gateway/alert/WoMessage.java
+++ b/src/main/java/medic/gateway/alert/WoMessage.java
@@ -120,7 +120,7 @@ class WoMessage {
 	 * @return time in milliseconds
 	 */
 	public int calcWaitTimeRetry(int retries) {
-		return (int) ( WAIT_RETRY_SOFT_FAIL * Math.pow(retries, 1.5) );
+		return (int) (WAIT_RETRY_SOFT_FAIL * Math.pow(retries, 1.5));
 	}
 
 	public boolean canRetryAfterSoftFail() {

--- a/src/test/java/medic/gateway/alert/DbTest.java
+++ b/src/test/java/medic/gateway/alert/DbTest.java
@@ -932,7 +932,7 @@ public class DbTest {
 	}
 
 	private static WoMessage aMessageWith(String id, WoMessage.Status status) {
-		return new WoMessage(id, status, null, System.currentTimeMillis(), A_PHONE_NUMBER, SOME_CONTENT);
+		return new WoMessage(id, status, null, System.currentTimeMillis(), A_PHONE_NUMBER, SOME_CONTENT, 0);
 	}
 
 	private static SmsMessage anSmsWith(String from, String content) {

--- a/src/test/java/medic/gateway/alert/DbTest.java
+++ b/src/test/java/medic/gateway/alert/DbTest.java
@@ -801,6 +801,34 @@ public class DbTest {
 
 //> MIGRATION TESTS
 	@Test
+	public void migrate_addRetriesColumn_WoMessage_ShouldAddColumn() {
+		// given: some messages exist
+		DbTestHelper dbHelper = anEmptyDbHelper();
+		dbHelper.raw.execSQL("CREATE TABLE wo_message (" +
+				"'_id' TEXT NOT NULL PRIMARY KEY, " +
+				"'status' TEXT NOT NULL, " +
+				"'failure_reason' TEXT, " +
+				"'last_action' INTEGER NOT NULL, " +
+				"'_to' TEXT NOT NULL, " +
+				"'content' TEXT NOT NULL)");
+
+		dbHelper.insert("wo_message",
+				cols("_id", "status", "failure_reason", "last_action", "_to", "content"),
+				vals("m-1", WoMessage.Status.UNSENT, null, 0, A_PHONE_NUMBER, ""),
+				vals("m-2", WoMessage.Status.PENDING, null, 0, A_PHONE_NUMBER, ""),
+				vals("m-3", WoMessage.Status.SENT, null, 0, A_PHONE_NUMBER, ""));
+
+		// when
+		Db.migrate_addRetriesColumn_WoMessage(dbHelper.raw);
+
+		// then
+		dbHelper.assertTable("wo_message",
+				"m-1", WoMessage.Status.UNSENT, null, ANY_NUMBER, ANY_PHONE_NUMBER, "", 0,
+				"m-2", WoMessage.Status.PENDING, null, ANY_NUMBER, ANY_PHONE_NUMBER, "", 0,
+				"m-3", WoMessage.Status.SENT, null, ANY_NUMBER, ANY_PHONE_NUMBER, "", 0);
+	}
+
+	@Test
 	public void migrate_createTable_WoMessageStatusUpdate_shouldCreateStatusesFromTheWoMessageTable() {
 		// given: some messages exist
 		DbTestHelper dbHelper = anEmptyDbHelper();

--- a/src/test/java/medic/gateway/alert/DbTest.java
+++ b/src/test/java/medic/gateway/alert/DbTest.java
@@ -403,8 +403,8 @@ public class DbTest {
 		// given: there is a message in the database which does NOT need forwarding
 		String messageId = randomUuid();
 		dbHelper.insert("wo_message",
-				cols("_id",        "status",                 "failure_reason", "last_action", "_to",          "content"),
-				vals(messageId,    WoMessage.Status.PENDING, null,             0,             A_PHONE_NUMBER, SOME_CONTENT));
+				cols("_id",        "status",                 "failure_reason", "last_action", "_to",          "content", "retries"),
+				vals(messageId,    WoMessage.Status.PENDING, null,             0,             A_PHONE_NUMBER, SOME_CONTENT, 0));
 		dbHelper.insert("wom_status",
 				cols("message_id", "status",                 "failure_reason", "timestamp", "needs_forwarding"),
 				vals(messageId,    WoMessage.Status.PENDING, null,             0,           false));
@@ -414,7 +414,7 @@ public class DbTest {
 
 		// then: none of the message details have changed except last action and needs forwarding
 		dbHelper.assertTable("wo_message",
-				messageId, "PENDING", null, GT_ZERO, A_PHONE_NUMBER, SOME_CONTENT);
+				messageId, "PENDING", null, GT_ZERO, A_PHONE_NUMBER, SOME_CONTENT, 0);
 		// and: the message's status has been marked as "needs forwarding"
 		dbHelper.assertTable("wom_status",
 				ANY_NUMBER, messageId, "PENDING", null, 0, true);
@@ -438,8 +438,8 @@ public class DbTest {
 		// given
 		String id = randomUuid();
 		dbHelper.insert("wo_message",
-				cols("_id", "status", "failure_reason", "last_action", "_to", "content"),
-				vals(id, WoMessage.Status.FAILED, "failure-reason", 0, A_PHONE_NUMBER, SOME_CONTENT));
+				cols("_id", "status", "failure_reason", "last_action", "_to", "content", "retries"),
+				vals(id, WoMessage.Status.FAILED, "failure-reason", 0, A_PHONE_NUMBER, SOME_CONTENT, 0));
 		dbHelper.insert("wom_status",
 				cols("message_id", "status",                 "failure_reason", "timestamp", "needs_forwarding"),
 				vals(id,           WoMessage.Status.FAILED,  null,             0,           false));
@@ -459,8 +459,8 @@ public class DbTest {
 		// given
 		String id = randomUuid();
 		dbHelper.insert("wo_message",
-				cols("_id", "status", "last_action", "_to", "content"),
-				vals(id, WoMessage.Status.PENDING, 0, A_PHONE_NUMBER, SOME_CONTENT));
+				cols("_id", "status", "last_action", "_to", "content", "retries"),
+				vals(id, WoMessage.Status.PENDING, 0, A_PHONE_NUMBER, SOME_CONTENT, 0));
 		dbHelper.insert("wom_status",
 				cols("message_id", "status",                 "failure_reason", "timestamp", "needs_forwarding"),
 				vals(id,           WoMessage.Status.PENDING, null,             0,           false));
@@ -572,11 +572,11 @@ public class DbTest {
 	public void deleteOldData_shouldDeleteOldWoMessagesButNotNewOnes() {
 		// given
 		dbHelper.insert("wo_message",
-				cols("_id",        "status",                 "last_action", "_to",          "content"),
-				vals(randomUuid(), WoMessage.Status.PENDING, now(),         A_PHONE_NUMBER, "should keep 1"),
-				vals(randomUuid(), WoMessage.Status.PENDING, daysAgo(8),    A_PHONE_NUMBER, "should delete 1"),
-				vals(randomUuid(), WoMessage.Status.PENDING, daysAgo(6),    A_PHONE_NUMBER, "should keep 2"),
-				vals(randomUuid(), WoMessage.Status.PENDING, daysAgo(800),  A_PHONE_NUMBER, "should delete 2"));
+				cols("_id",        "status",                 "last_action", "_to",          "content", "retries"),
+				vals(randomUuid(), WoMessage.Status.PENDING, now(),         A_PHONE_NUMBER, "should keep 1", 0),
+				vals(randomUuid(), WoMessage.Status.PENDING, daysAgo(8),    A_PHONE_NUMBER, "should delete 1", 0),
+				vals(randomUuid(), WoMessage.Status.PENDING, daysAgo(6),    A_PHONE_NUMBER, "should keep 2", 0),
+				vals(randomUuid(), WoMessage.Status.PENDING, daysAgo(800),  A_PHONE_NUMBER, "should delete 2", 0));
 		dbHelper.assertCount("wo_message", 4);
 
 		// when
@@ -585,8 +585,8 @@ public class DbTest {
 		// then
 		assertEquals(2, deletedCount);
 		dbHelper.assertTable("wo_message",
-				ANY_ID, "PENDING", null, ANY_NUMBER, A_PHONE_NUMBER, "should keep 1",
-				ANY_ID, "PENDING", null, ANY_NUMBER, A_PHONE_NUMBER, "should keep 2");
+				ANY_ID, "PENDING", null, ANY_NUMBER, A_PHONE_NUMBER, "should keep 1", 0,
+				ANY_ID, "PENDING", null, ANY_NUMBER, A_PHONE_NUMBER, "should keep 2", 0);
 	}
 
 	@Test
@@ -617,8 +617,8 @@ public class DbTest {
 				cols("_id", "timestamp", "message"),
 				vals(1,     daysAgo(8),  "Should be deleted"));
 		dbHelper.insert("wo_message",
-				cols("_id",        "status",                 "last_action", "_to",          "content"),
-				vals(randomUuid(), WoMessage.Status.PENDING, daysAgo(8),    A_PHONE_NUMBER, "should delete"));
+				cols("_id",        "status",                 "last_action", "_to",          "content", "retries"),
+				vals(randomUuid(), WoMessage.Status.PENDING, daysAgo(8),    A_PHONE_NUMBER, "should delete", 0));
 		dbHelper.insert("wt_message",
 				cols("_id",        "status",                 "last_action", "_from",        "content",         "sms_sent", "sms_received"),
 				vals(randomUuid(), WoMessage.Status.PENDING, daysAgo(8),    A_PHONE_NUMBER, "should delete 1", 0,          0));
@@ -742,22 +742,22 @@ public class DbTest {
 	public void generateMessageReport_shouldCountThingsReliably() {
 		// given
 		dbHelper.insert("wo_message",
-				cols("_id",        "status",                  "last_action", "_to",          "content"),
-				vals(randomUuid(), WoMessage.Status.UNSENT,   0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.PENDING,  0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.PENDING,  0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.SENT,     0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.SENT,     0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.SENT,     0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.FAILED,   0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.FAILED,   0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.FAILED,   0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.FAILED,   0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.DELIVERED,0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.DELIVERED,0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.DELIVERED,0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.DELIVERED,0,             A_PHONE_NUMBER, ""),
-				vals(randomUuid(), WoMessage.Status.DELIVERED,0,             A_PHONE_NUMBER, ""));
+				cols("_id",        "status",                  "last_action", "_to",          "content", "retries"),
+				vals(randomUuid(), WoMessage.Status.UNSENT,   0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.PENDING,  0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.PENDING,  0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.SENT,     0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.SENT,     0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.SENT,     0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.FAILED,   0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.FAILED,   0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.FAILED,   0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.FAILED,   0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.DELIVERED,0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.DELIVERED,0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.DELIVERED,0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.DELIVERED,0,             A_PHONE_NUMBER, "", 0),
+				vals(randomUuid(), WoMessage.Status.DELIVERED,0,             A_PHONE_NUMBER, "", 0));
 		dbHelper.insert("wt_message",
 				cols("_id",        "status",                   "last_action", "_from",        "content",    "sms_sent", "sms_received"),
 				vals(randomUuid(), WtMessage.Status.WAITING,   0,             A_PHONE_NUMBER, SOME_CONTENT, 0,          0),

--- a/src/test/java/medic/gateway/alert/SmsSenderTest.java
+++ b/src/test/java/medic/gateway/alert/SmsSenderTest.java
@@ -48,8 +48,8 @@ public class SmsSenderTest {
 		for(Status s : Status.values()) {
 			// create a WoMessage with each status
 			db.insert("wo_message",
-					cols("_id",     "status", "failure_reason", "last_action", "_to", "content"),
-					vals("id-" + s, s,        null,             0,             "+1",  "testing: " + s));
+					cols("_id",     "status", "failure_reason", "last_action", "_to", "content", "retries"),
+					vals("id-" + s, s,        null,             0,             "+1",  "testing: " + s, 0));
 		}
 
 		// when
@@ -57,11 +57,11 @@ public class SmsSenderTest {
 
 		// then
 		db.assertTable("wo_message",
-				"id-UNSENT",    "PENDING",   null, ANY_NUMBER, "+1", "testing: UNSENT",
-				"id-PENDING",   "PENDING",   null, 0,          "+1", "testing: PENDING",
-				"id-SENT",      "SENT",      null, 0,          "+1", "testing: SENT",
-				"id-FAILED",    "FAILED",    null, 0,          "+1", "testing: FAILED",
-				"id-DELIVERED", "DELIVERED", null, 0,          "+1", "testing: DELIVERED");
+				"id-UNSENT",    "PENDING",   null, ANY_NUMBER, "+1", "testing: UNSENT", 0,
+				"id-PENDING",   "PENDING",   null, 0,          "+1", "testing: PENDING", 0,
+				"id-SENT",      "SENT",      null, 0,          "+1", "testing: SENT", 0,
+				"id-FAILED",    "FAILED",    null, 0,          "+1", "testing: FAILED", 0,
+				"id-DELIVERED", "DELIVERED", null, 0,          "+1", "testing: DELIVERED", 0);
 	}
 
 	@Test
@@ -70,8 +70,8 @@ public class SmsSenderTest {
 		for(Status s : Status.values()) {
 			// create a WoMessage with each status
 			db.insert("wo_message",
-					cols("_id",     "status", "last_action", "_to", "content"),
-					vals("id-" + s, s,        0,             "+1",  "testing: " + s));
+					cols("_id",     "status", "last_action", "_to", "content", "retries"),
+					vals("id-" + s, s,        0,             "+1",  "testing: " + s, 0));
 		}
 
 		// when
@@ -148,15 +148,15 @@ public class SmsSenderTest {
 		// given
 		enableDummySendMode();
 		db.insert("wo_message",
-				cols("_id",    "status", "failure_reason", "last_action", "_to", "content"),
-				vals("id-123", UNSENT,   null,             0,             "+1",  "testing"));
+				cols("_id",    "status", "failure_reason", "last_action", "_to", "content", "retries"),
+				vals("id-123", UNSENT,   null,             0,             "+1",  "testing", 0));
 
 		// when
 		smsSender.sendUnsentSmses();
 
 		// then
 		db.assertTable("wo_message",
-				"id-123", "DELIVERED", null, ANY_NUMBER, "+1", "testing");
+				"id-123", "DELIVERED", null, ANY_NUMBER, "+1", "testing", 0);
 		db.assertTable("wom_status",
 				ANY_ID, "id-123", "PENDING",   null, ANY_NUMBER, true,
 				ANY_ID, "id-123", "SENT",      null, ANY_NUMBER, true,

--- a/src/test/java/medic/gateway/alert/SmsSenderTest.java
+++ b/src/test/java/medic/gateway/alert/SmsSenderTest.java
@@ -68,7 +68,7 @@ public class SmsSenderTest {
 	public void sendUnsentSmses_shouldRetryToSendUnsentSmsWhenItsTime() {
 		// given
 		long lastAction = System.currentTimeMillis();
-		long lastActionPast = lastAction - 540000; // 9 min in milliseconds
+		long lastActionPast = lastAction - 180000; // 3 min in milliseconds
 
 		db.insert("wo_message",
 				cols("_id", "status", "failure_reason", "last_action", "_to", "content", "retries"),

--- a/src/test/java/medic/gateway/alert/SmsSenderTest.java
+++ b/src/test/java/medic/gateway/alert/SmsSenderTest.java
@@ -43,7 +43,7 @@ public class SmsSenderTest {
 	}
 
 	@Test
-	public void sendUnsentSmses_shouldOnlyTryToSendUnentSms() {
+	public void sendUnsentSmses_shouldOnlyTryToSendUnsentSms() {
 		// given
 		for(Status s : Status.values()) {
 			// create a WoMessage with each status
@@ -62,6 +62,34 @@ public class SmsSenderTest {
 				"id-SENT",      "SENT",      null, 0,          "+1", "testing: SENT", 0,
 				"id-FAILED",    "FAILED",    null, 0,          "+1", "testing: FAILED", 0,
 				"id-DELIVERED", "DELIVERED", null, 0,          "+1", "testing: DELIVERED", 0);
+	}
+
+	@Test
+	public void sendUnsentSmses_shouldRetryToSendUnsentSmsWhenItsTime() {
+		// given
+		long lastAction = System.currentTimeMillis();
+		long lastActionPast = lastAction - 540000; // 9 min in milliseconds
+
+		db.insert("wo_message",
+				cols("_id", "status", "failure_reason", "last_action", "_to", "content", "retries"),
+				// It's not time to retry yet
+				vals("id-UNSENT-1", UNSENT, null, lastAction, "+1", "testing", 5),
+				// It's time, ready to send
+				vals("id-UNSENT-2", UNSENT, null, lastActionPast, "+1", "testing", 2),
+				// New sms, not retry flow.
+				vals("id-UNSENT-3", UNSENT, null, lastAction, "+1", "testing", 0),
+				// No retry, exceeding maximum number of retries.
+				vals("id-UNSENT-4", UNSENT, null, lastAction, "+1", "testing", 21));
+
+		// when
+		smsSender.sendUnsentSmses();
+
+		// then
+		db.assertTable("wo_message",
+				"id-UNSENT-1", UNSENT, null, ANY_NUMBER, "+1", "testing", 5,
+				"id-UNSENT-2", PENDING, null, ANY_NUMBER, "+1", "testing", 2,
+				"id-UNSENT-3", PENDING, null, ANY_NUMBER, "+1", "testing", 0,
+				"id-UNSENT-4", UNSENT, null, ANY_NUMBER, "+1", "testing", 21);
 	}
 
 	@Test


### PR DESCRIPTION
# Description

This PR will introduce a soft fail with retry process for SMS that works as follows:

1.. If It’s temporary error, soft fail the sms, this means:
        1.1 SMS will be back to `UNSENT` status, so Gateway will pick it up again automatically
        1.2 SMS’ retries counter increases by 1
        1.3 Log that X error occurred and that will retry for the X time in X minutes

2.. If sms’ maximum of retries are reached then
        2.1 Hard fail: SMS status will be `FAILED` and stop retries
        2.2 Log error
        2.3 Counter retries reset to 0

3.. At this point the user can manually select the message and press `Retry` button, if necessary
        3.1 If they do, then it goes back to step # 1 in case the SMS fails again…

I couldn't add any [new error code](https://developer.android.com/reference/android/telephony/SmsManager#RESULT_RIL_NETWORK_ERR) for SMS, since we are supporting older versions of Android and most of the nice ones were added in SDK 30.

**This PR is dependant of this one:**  https://github.com/medic/medic-gateway/pull/158

**To AT:** My test device at the moment is Android 9. Can you please test this in older Android version? Thanks!

https://github.com/medic/medic-gateway/issues/139

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
