### PR TITLE
142 mark messages received by gateway

### DIFF
--- a/src/androidTest/java/medic/gateway/alert/WebappPollerTest.java
+++ b/src/androidTest/java/medic/gateway/alert/WebappPollerTest.java
@@ -119,7 +119,7 @@ public class WebappPollerTest extends AndroidTestCase {
 		db.assertTable("wo_message",
 				ANY_ID, "DELIVERED", NO_REASON, 0, A_PHONE_NUMBER, SOME_CONTENT, 0);
 		db.assertTable("wom_status",
-				ANY_NUMBER, messageId, "DELIVERED", NO_REASON, 0, true);
+				ANY_NUMBER, messageId, "DELIVERED", NO_REASON, 0, false);
 	}
 
 	@Test

--- a/src/androidTest/java/medic/gateway/alert/WebappPollerTest.java
+++ b/src/androidTest/java/medic/gateway/alert/WebappPollerTest.java
@@ -119,7 +119,7 @@ public class WebappPollerTest extends AndroidTestCase {
 		db.assertTable("wo_message",
 				ANY_ID, "DELIVERED", NO_REASON, 0, A_PHONE_NUMBER, SOME_CONTENT, 0);
 		db.assertTable("wom_status",
-				ANY_NUMBER, messageId, "DELIVERED", NO_REASON, 0, false);
+				ANY_NUMBER, messageId, "DELIVERED", NO_REASON, 0, true);
 	}
 
 	@Test
@@ -239,8 +239,8 @@ public class WebappPollerTest extends AndroidTestCase {
 				"aaa-111", "UNSENT", NO_REASON, ANY_NUMBER, "+1", "testing: one", 0,
 				"aaa-222", "UNSENT", NO_REASON, ANY_NUMBER, "+2", "testing: two", 0);
 		db.assertTable("wom_status",
-				ANY_NUMBER, "aaa-111", "UNSENT", NO_REASON, ANY_NUMBER, false,
-				ANY_NUMBER, "aaa-222", "UNSENT", NO_REASON, ANY_NUMBER, false);
+				ANY_NUMBER, "aaa-111", "UNSENT", NO_REASON, ANY_NUMBER, true,
+				ANY_NUMBER, "aaa-222", "UNSENT", NO_REASON, ANY_NUMBER, true);
 	}
 
 	@Test
@@ -260,7 +260,7 @@ public class WebappPollerTest extends AndroidTestCase {
 		db.assertTable("wo_message",
 				"abc-123", "UNSENT", NO_REASON, ANY_NUMBER, "+123", "testing: abc", 0);
 		db.assertTable("wom_status",
-				ANY_NUMBER, "abc-123", "UNSENT", NO_REASON, ANY_NUMBER, false);
+				ANY_NUMBER, "abc-123", "UNSENT", NO_REASON, ANY_NUMBER, true);
 	}
 
 	@Test
@@ -301,7 +301,7 @@ public class WebappPollerTest extends AndroidTestCase {
 				"ok-111", "UNSENT", NO_REASON, ANY_NUMBER, "+1", "ok: one", 0,
 				"ok-222", "UNSENT", NO_REASON, ANY_NUMBER, "+2", "ok: two", 0);
 		db.assertTable("wom_status",
-				ANY_NUMBER, "ok-111", "UNSENT", NO_REASON, ANY_NUMBER, false,
-				ANY_NUMBER, "ok-222", "UNSENT", NO_REASON, ANY_NUMBER, false);
+				ANY_NUMBER, "ok-111", "UNSENT", NO_REASON, ANY_NUMBER, true,
+				ANY_NUMBER, "ok-222", "UNSENT", NO_REASON, ANY_NUMBER, true);
 	}
 }

--- a/src/main/java/medic/gateway/alert/Db.java
+++ b/src/main/java/medic/gateway/alert/Db.java
@@ -317,7 +317,7 @@ public final class Db extends SQLiteOpenHelper {
 			long id = db.insertOrThrow(tblWO_MESSAGE, null, getContentValues(m));
 
 			if(id != -1) {
-				storeStatusUpdate(m, m.status, null, m.lastAction, false);
+				storeStatusUpdate(m, m.status, null, m.lastAction);
 				return true;
 			} else {
 				return false;
@@ -380,7 +380,7 @@ public final class Db extends SQLiteOpenHelper {
 		}
 
 		if(affected > 0) {
-			storeStatusUpdate(m, newStatus, failureReason, timestamp, true);
+			storeStatusUpdate(m, newStatus, failureReason, timestamp);
 			return true;
 		} else {
 			return false;
@@ -419,9 +419,9 @@ public final class Db extends SQLiteOpenHelper {
 		}
 	}
 
-	private void storeStatusUpdate(WoMessage m, WoMessage.Status newStatus, String failureReason, long timestamp, boolean needsForwarding) {
+	private void storeStatusUpdate(WoMessage m, WoMessage.Status newStatus, String failureReason, long timestamp) {
 		try {
-			db.insertOrThrow(tblWO_STATUS, null, getContentValues(m, newStatus, failureReason, timestamp, needsForwarding));
+			db.insertOrThrow(tblWO_STATUS, null, getContentValues(m, newStatus, failureReason, timestamp, true));
 		} catch(SQLException ex) {
 			warnException(ex, "Exception writing WO StatusUpdate [%s] to db for WoMessage: %s", newStatus, m);
 		}

--- a/src/test/java/medic/gateway/alert/DbTest.java
+++ b/src/test/java/medic/gateway/alert/DbTest.java
@@ -488,7 +488,7 @@ public class DbTest {
 
 		// then
 		dbHelper.assertTable("wom_status",
-				ANY_NUMBER, m.id, "UNSENT", null, ANY_NUMBER, false);
+				ANY_NUMBER, m.id, "UNSENT", null, ANY_NUMBER, true);
 	}
 
 	@Test
@@ -504,7 +504,7 @@ public class DbTest {
 
 		// then
 		dbHelper.assertTable("wom_status",
-				ANY_NUMBER, m.id, "UNSENT", null, ANY_NUMBER, false,
+				ANY_NUMBER, m.id, "UNSENT", null, ANY_NUMBER, true,
 				ANY_NUMBER, m.id, "PENDING", null, ANY_NUMBER, true);
 	}
 


### PR DESCRIPTION
# Description

This PR will set the SMS status as `Needs Forwarding` when updating statuses or when saving new SMS to Gateway DB. Then Gateway will notify the status change to API from the beginning, reducing the chance of API to resend the same SMS.

**This PR is dependant of this one:**  https://github.com/medic/medic-gateway/pull/159

**To AT:** My test device at the moment is Android 9. Can you please test this in older Android version? Thanks!

https://github.com/medic/medic-gateway/issues/142

# Code review items

- Readable: Concise, well named, follows the [style guide](https://github.com/medic/medic-docs/blob/master/development/style-guide.md), documented if necessary.
- Documented: Configuration and user documentation on [medic-docs](https://github.com/medic/medic-docs/)
- Tested: Unit and/or e2e where appropriate
- Internationalised: All user facing text
- Backwards compatible: Works with existing data and configuration or includes a migration. Any breaking changes documented in Changes.md.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
